### PR TITLE
Use the 'dynamic' bevy feature flag for faster iterative compile times

### DIFF
--- a/crates/bomber_game/Cargo.toml
+++ b/crates/bomber_game/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 
 [dependencies]
 wasmtime = "0.30"
-bevy = "0.5"
+# TODO(bschwind) - Remove the 'dynamic' feature flag before deployment of the final version.
+bevy = { version = "0.5", features = ["dynamic"] }
 anyhow = "1"
 
 [dependencies.bomber_lib]


### PR DESCRIPTION
Reference: https://bevyengine.org/learn/book/getting-started/setup/

Some rough numbers from a 2020 macbook pro (pre-M1 :c), making a one line change to `main.rs` and recompiling after the first full build:

## Before
```
brian bomberman-of-the-hill $ cargo build --release -p bomber_game
   Compiling bomber_game v0.1.0 (/Users/brian/projects/tonari/bomberman-of-the-hill/crates/bomber_game)
    Finished release [optimized] target(s) in 19.32s
```

## After
```
brian bomberman-of-the-hill $ cargo build --release -p bomber_game
   Compiling bomber_game v0.1.0 (/Users/brian/projects/tonari/bomberman-of-the-hill/crates/bomber_game)
    Finished release [optimized] target(s) in 7.19s
```

Also as a note, we may want to pick and choose which parts of bevy we want to use. A clean build on my machine took `6m 23s`. 

I have a [project](https://github.com/bschwind/simple-game/blob/70060b3023944fd9774de6fd7a8d9cac2685d8d2/examples/bevy_example.rs) which uses just the ECS part of bevy, along with `winit` and `wgpu`. It takes `1m 27s` for a clean build.

I think it makes sense to start with everything for now, but let's carve it down to size as we understand what we want or don't want.