### PR TITLE
Migrate from bevy 0.6 to bevy 0.7

### DIFF
--- a/crates/bomber_game/Cargo.toml
+++ b/crates/bomber_game/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 wasmtime = "0.30"
 # TODO(bschwind) - Remove the 'dynamic' feature flag before deployment of the final version.
-bevy = { version = "0.6", features = ["dynamic"] }
+bevy = { version = "0.7", features = ["dynamic"] }
 anyhow = "1"
 rand = "0.8"
 

--- a/crates/bomber_game/src/bomb.rs
+++ b/crates/bomber_game/src/bomb.rs
@@ -73,13 +73,13 @@ impl Plugin for BombPlugin {
             .add_event::<SpawnBombEvent>()
             .add_system_set(
                 SystemSet::on_update(AppState::InGame)
-                    .with_system(bomb_spawn_system.system())
-                    .with_system(fuse_remaining_system.system())
-                    .with_system(bomb_explosion_system.system())
-                    .with_system(objects_on_fire_system.system())
-                    .with_system(explosion_despawn_system.system()),
+                    .with_system(bomb_spawn_system)
+                    .with_system(fuse_remaining_system)
+                    .with_system(bomb_explosion_system)
+                    .with_system(objects_on_fire_system)
+                    .with_system(explosion_despawn_system),
             )
-            .add_system_set(SystemSet::on_exit(AppState::InGame).with_system(cleanup.system()));
+            .add_system_set(SystemSet::on_exit(AppState::InGame).with_system(cleanup));
     }
 }
 

--- a/crates/bomber_game/src/game_map.rs
+++ b/crates/bomber_game/src/game_map.rs
@@ -50,12 +50,12 @@ impl Plugin for GameMapPlugin {
         app.insert_resource(textures)
             .add_system_set(
                 SystemSet::on_enter(AppState::InGame)
-                    .with_system(setup.system().chain(log_unrecoverable_error_and_panic.system())),
+                    .with_system(setup.chain(log_unrecoverable_error_and_panic)),
             )
             // Keep the game map on the victory screen as the background.
             .add_system_set(
                 SystemSet::on_exit(AppState::VictoryScreen)
-                .with_system(cleanup.system().chain(log_unrecoverable_error_and_panic.system())));
+                .with_system(cleanup.chain(log_unrecoverable_error_and_panic)));
     }
 }
 

--- a/crates/bomber_game/src/main.rs
+++ b/crates/bomber_game/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
         .add_plugin(PlayerHotswapPlugin)
         .add_plugin(BombPlugin)
         .add_plugin(VictoryScreenPlugin)
-        .add_startup_system(setup.system())
+        .add_startup_system(setup)
         .run();
     Ok(())
 }

--- a/crates/bomber_game/src/player_hotswap.rs
+++ b/crates/bomber_game/src/player_hotswap.rs
@@ -49,7 +49,7 @@ impl Plugin for PlayerHotswapPlugin {
         app.insert_resource(PlayerHandles(vec![]))
             .add_asset::<WasmPlayerAsset>()
             .init_asset_loader::<WasmPlayerLoader>()
-            .add_system(hotswap_system.system());
+            .add_system(hotswap_system);
     }
 }
 

--- a/crates/bomber_game/src/score.rs
+++ b/crates/bomber_game/src/score.rs
@@ -9,7 +9,7 @@ pub struct Score(pub u32);
 
 impl Plugin for ScorePlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(hill_score_system.system());
+        app.add_system(hill_score_system);
     }
 }
 

--- a/crates/bomber_game/src/victory_screen.rs
+++ b/crates/bomber_game/src/victory_screen.rs
@@ -26,16 +26,15 @@ impl Plugin for VictoryScreenPlugin {
 
         let fonts = Fonts { mono: asset_server.load("fonts/space_mono_400.ttf") };
         app.insert_resource(fonts);
-        app.add_system_set(
-            SystemSet::on_enter(AppState::VictoryScreen).with_system(setup.system()),
-        )
-        .add_system_set(SystemSet::on_update(AppState::VictoryScreen).with_system(
-            countdown_text_system.system().chain(log_unrecoverable_error_and_panic.system()),
-        ))
-        .add_system_set(
-            SystemSet::on_exit(AppState::VictoryScreen)
-                .with_system(cleanup.system().chain(log_unrecoverable_error_and_panic.system())),
-        );
+        app.add_system_set(SystemSet::on_enter(AppState::VictoryScreen).with_system(setup))
+            .add_system_set(
+                SystemSet::on_update(AppState::VictoryScreen)
+                    .with_system(countdown_text_system.chain(log_unrecoverable_error_and_panic)),
+            )
+            .add_system_set(
+                SystemSet::on_exit(AppState::VictoryScreen)
+                    .with_system(cleanup.chain(log_unrecoverable_error_and_panic)),
+            );
     }
 }
 
@@ -114,10 +113,10 @@ fn spawn_countdown_text(parent: &mut ChildBuilder, fonts: &Fonts) {
 }
 
 fn countdown_text_system(
-    timer_query: Query<&Timer, With<AppStateTimer>>,
+    timer_query: Query<&AppStateTimer>,
     mut count_down_text_query: Query<&mut Text, With<CountdownText>>,
 ) -> Result<()> {
-    let timer = timer_query.single();
+    let AppStateTimer(timer) = timer_query.single();
     let remaining = timer.duration() - timer.elapsed();
 
     let mut count_down_text = count_down_text_query.single_mut();


### PR DESCRIPTION
This migration was a lot less painful, and mostly dealing with the fact that timers are not components anymore (so they need to be wrapped) and with the fact that calling `system` is now marked as deprecated.