### PR TITLE
Add round countdown and score tracker

### DIFF
--- a/crates/bomber_game/Cargo.toml
+++ b/crates/bomber_game/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 wasmtime = "0.38"
 # TODO(bschwind) - Remove the 'dynamic' feature flag before deployment of the final version.
 bevy = { version = "0.7", features = ["dynamic"] }
+bevy_egui = "0.14"
 anyhow = "1"
 rand = "0.8"
 

--- a/crates/bomber_game/src/game_ui.rs
+++ b/crates/bomber_game/src/game_ui.rs
@@ -1,0 +1,136 @@
+use bevy::prelude::*;
+use bevy_egui::{
+    egui::{self, epaint::Shadow, style::Widgets, Color32, RichText, Stroke},
+    EguiContext, EguiPlugin,
+};
+
+use crate::{
+    player_behaviour::{KillPlayerEvent, PlayerName, SpawnPlayerEvent},
+    score::Score,
+    state::{AppState, RoundTimer},
+};
+
+pub struct GameUiPlugin;
+
+/// Marker component that identifies a score/name pair as belonging to a dead
+/// (despawned) player, so their last score is visible until they respawn.
+#[derive(Component)]
+struct DeadPlayerScore;
+
+impl Plugin for GameUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugin(EguiPlugin);
+        app.add_system(dead_player_score_system);
+        app.add_system_set(SystemSet::on_update(AppState::InGame).with_system(score_panel_system));
+        app.add_startup_system(configure_visuals);
+    }
+}
+
+fn score_panel_system(
+    mut egui_context: ResMut<EguiContext>,
+    player_query: Query<(&PlayerName, &Score, Option<&DeadPlayerScore>)>,
+    round_timer_query: Query<&RoundTimer>,
+) {
+    let mut score_entries = player_query.iter().collect::<Vec<_>>();
+    // Sort by descending score
+    score_entries.sort_by(|(_, Score(a), _), (_, Score(b), _)| b.cmp(a));
+    let timer = round_timer_query.single();
+    let remaining = timer.0.duration() - timer.0.elapsed();
+    let (minutes, seconds) = (remaining.as_secs() / 60, remaining.as_secs() % 60);
+
+    egui::SidePanel::left("Player Score").resizable(false).show(egui_context.ctx_mut(), |ui| {
+        ui.vertical_centered_justified(|ui| {
+            let label_text =
+                RichText::new(format!("Round ends in {minutes}:{seconds:02}")).size(25.0);
+            ui.label(label_text);
+            ui.separator();
+            ui.heading(RichText::new("Player Score").strong());
+            egui::Grid::new("Score Grid").striped(true).show(ui, |ui| {
+                for (PlayerName(name), score, dead_marker) in score_entries.iter() {
+                    ui.colored_label(
+                        if dead_marker.is_some() {
+                            tonari_color::STRAWBERRY_LETTER_23
+                        } else {
+                            tonari_color::MIDNIGHT
+                        },
+                        name,
+                    );
+                    ui.label(format!(
+                        "{}{}",
+                        score.0,
+                        if dead_marker.is_some() { " (Dead)" } else { "" }
+                    ));
+                    ui.end_row();
+                }
+                ui.allocate_space(ui.available_size());
+            });
+        });
+    });
+}
+
+fn dead_player_score_system(
+    mut spawn_events: EventReader<SpawnPlayerEvent>,
+    mut kill_events: EventReader<KillPlayerEvent>,
+    mut commands: Commands,
+    dead_player_scores: Query<(Entity, &DeadPlayerScore, &PlayerName)>,
+) {
+    for SpawnPlayerEvent(name) in spawn_events.iter() {
+        if let Some(entity) =
+            dead_player_scores.iter().find_map(|(e, _, n)| (n.0 == name.0).then(|| e))
+        {
+            commands.entity(entity).despawn_recursive();
+        }
+    }
+    for KillPlayerEvent(_, name, score) in kill_events.iter() {
+        // The player themselves will be despawned this frame, but we instead insert a score marker that will persist
+        // until they despawn.
+        commands.spawn().insert(name.clone()).insert(*score).insert(DeadPlayerScore);
+    }
+}
+
+fn configure_visuals(mut egui_ctx: ResMut<EguiContext>) {
+    let faded_little_dragon = Color32::from_rgb(102, 178, 162);
+    let mut widgets = Widgets::light();
+    widgets.noninteractive.bg_fill = tonari_color::LITTLE_DRAGON;
+    widgets.noninteractive.bg_stroke = Stroke { color: tonari_color::PURPLE_RAIN, width: 1.0 };
+    widgets.noninteractive.fg_stroke = Stroke { color: tonari_color::PURPLE_RAIN, width: 3.0 };
+
+    let visuals = egui::Visuals {
+        dark_mode: false,
+        window_rounding: 0.0.into(),
+        widgets,
+        window_shadow: Shadow { extrusion: 0.0, color: tonari_color::GREEN_DAY },
+        faint_bg_color: faded_little_dragon,
+        ..Default::default()
+    };
+    egui_ctx.ctx_mut().set_visuals(visuals);
+}
+
+#[allow(unused)]
+pub mod tonari_color {
+    use super::egui::Color32;
+    pub const BLUE_MOON: Color32 = Color32::from_rgb(50, 108, 242);
+    pub const GREEN_DAY: Color32 = Color32::from_rgb(38, 201, 140);
+    pub const THE_WHITE_STRIPES: Color32 = Color32::from_rgb(254, 251, 244);
+    pub const RECYCLED_AIR: Color32 = Color32::from_rgb(248, 249, 234);
+    pub const CHROMEO: Color32 = Color32::from_rgb(211, 210, 215);
+    pub const DEEP_PURPLE: Color32 = Color32::from_rgb(54, 60, 89);
+    pub const LOVE: Color32 = Color32::from_rgb(218, 53, 117);
+    pub const RED_HOT_CHILI_PEPPERS: Color32 = Color32::from_rgb(236, 91, 99);
+    pub const STRAWBERRY_LETTER_23: Color32 = Color32::from_rgb(235, 98, 81);
+    pub const DJ_MUSTARD: Color32 = Color32::from_rgb(243, 174, 86);
+    pub const YELLOW_SUBMARINE: Color32 = Color32::from_rgb(246, 201, 98);
+    pub const LITTLE_DRAGON: Color32 = Color32::from_rgb(122, 198, 182);
+    pub const MY_LIFE_IS_SO_BLUE: Color32 = Color32::from_rgb(18, 47, 161);
+    pub const PURPLE_RAIN: Color32 = Color32::from_rgb(84, 68, 150);
+    pub const PINK_FLOYD: Color32 = Color32::from_rgb(247, 203, 210);
+    pub const YOSHIMI_BATTLES_THE_PINK_ROBOTS: Color32 = Color32::from_rgb(255, 150, 148);
+    pub const O_SOLE_MIO: Color32 = Color32::from_rgb(252, 254, 164);
+    pub const MINT_CONDITION: Color32 = Color32::from_rgb(212, 250, 204);
+    pub const LILAC_WINE: Color32 = Color32::from_rgb(185, 182, 225);
+    pub const RUSTIE: Color32 = Color32::from_rgb(202, 182, 173);
+    pub const JAMES_BROWN: Color32 = Color32::from_rgb(146, 129, 122);
+    pub const ANOTHER_GREEN_WORLD: Color32 = Color32::from_rgb(178, 195, 145);
+    pub const MIDNIGHT: Color32 = Color32::from_rgb(76, 81, 105);
+    pub const PURE_SHORES: Color32 = Color32::from_rgb(255, 255, 255);
+}

--- a/crates/bomber_game/src/main.rs
+++ b/crates/bomber_game/src/main.rs
@@ -6,6 +6,7 @@ use bevy::prelude::*;
 use bomb::BombPlugin;
 
 use game_map::GameMapPlugin;
+use game_ui::GameUiPlugin;
 use player_behaviour::PlayerBehaviourPlugin;
 use player_hotswap::PlayerHotswapPlugin;
 use score::ScorePlugin;
@@ -15,6 +16,7 @@ use victory_screen::VictoryScreenPlugin;
 
 mod bomb;
 mod game_map;
+mod game_ui;
 mod player_behaviour;
 mod player_hotswap;
 mod rendering;
@@ -52,6 +54,7 @@ fn main() -> Result<()> {
         .add_plugin(PlayerHotswapPlugin)
         .add_plugin(BombPlugin)
         .add_plugin(VictoryScreenPlugin)
+        .add_plugin(GameUiPlugin)
         .add_startup_system(setup)
         .run();
     Ok(())

--- a/crates/bomber_game/src/state.rs
+++ b/crates/bomber_game/src/state.rs
@@ -21,7 +21,7 @@ const GAME_DURATION: Duration = Duration::from_secs(5 * 60);
 const VICTORY_SCREEN_DURATION: Duration = Duration::from_secs(30);
 
 #[derive(Component)]
-pub struct AppStateTimer(pub Timer);
+pub struct RoundTimer(pub Timer);
 
 impl Plugin for AppStatePlugin {
     fn build(&self, app: &mut App) {
@@ -32,18 +32,18 @@ impl Plugin for AppStatePlugin {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn().insert(AppStateTimer(Timer::new(GAME_DURATION, false)));
+    commands.spawn().insert(RoundTimer(Timer::new(GAME_DURATION, false)));
 }
 
 fn app_state_system(
-    mut timer_query: Query<(Entity, &mut AppStateTimer)>,
+    mut timer_query: Query<(Entity, &mut RoundTimer)>,
     time: Res<Time>,
     mut app_state: ResMut<State<AppState>>,
     mut commands: Commands,
 ) -> Result<()> {
     let (timer_entity, mut timer) = timer_query.single_mut();
 
-    let AppStateTimer(ref mut timer) = *timer;
+    let RoundTimer(ref mut timer) = *timer;
     if timer.tick(time.delta()).just_finished() {
         let (next_state, next_duration) = match app_state.current() {
             AppState::InGame => (AppState::VictoryScreen, VICTORY_SCREEN_DURATION),
@@ -51,7 +51,7 @@ fn app_state_system(
         };
         app_state.set(next_state)?;
         commands.entity(timer_entity).despawn();
-        commands.spawn().insert(AppStateTimer(Timer::new(next_duration, false)));
+        commands.spawn().insert(RoundTimer(Timer::new(next_duration, false)));
     }
 
     Ok(())

--- a/crates/bomber_game/src/victory_screen.rs
+++ b/crates/bomber_game/src/victory_screen.rs
@@ -6,7 +6,7 @@ use crate::{
     player_behaviour::PlayerName,
     rendering::{PLAYER_HEIGHT_PX, PLAYER_WIDTH_PX, VICTORY_SCREEN_ITEMS_Z, VICTORY_SCREEN_Z},
     score::Score,
-    state::{AppState, AppStateTimer},
+    state::{AppState, RoundTimer},
 };
 
 pub struct VictoryScreenPlugin;
@@ -113,10 +113,10 @@ fn spawn_countdown_text(parent: &mut ChildBuilder, fonts: &Fonts) {
 }
 
 fn countdown_text_system(
-    timer_query: Query<&AppStateTimer>,
+    timer_query: Query<&RoundTimer>,
     mut count_down_text_query: Query<&mut Text, With<CountdownText>>,
 ) -> Result<()> {
-    let AppStateTimer(timer) = timer_query.single();
+    let RoundTimer(timer) = timer_query.single();
     let remaining = timer.duration() - timer.elapsed();
 
     let mut count_down_text = count_down_text_query.single_mut();


### PR DESCRIPTION
Adds a basic EGUI ui to track player scores (with a contingency for dead players) and a countdown to the next round. This is the bare minimum UI for a functional game, though we may want to expand it a bit.

Relates to #6, but I wouldn't quite say it closes it yet.