### PR TITLE
Fix Victory screen podium

### DIFF
--- a/crates/bomber_game/src/animation.rs
+++ b/crates/bomber_game/src/animation.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bevy::prelude::*;
 use bomber_lib::world;
 
-use crate::tick::WHOLE_TURN_PERIOD;
+use crate::{state::AppState, tick::WHOLE_TURN_PERIOD};
 
 pub struct AnimationPlugin;
 pub struct AnimationTimer(Timer);
@@ -41,7 +41,9 @@ impl AnimationState {
 
 impl Plugin for AnimationPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(animate_bomberman_system);
+        app.add_system_set(
+            SystemSet::on_update(AppState::InGame).with_system(animate_bomberman_system),
+        );
         app.insert_resource(AnimationTimer(Timer::new(animation_period(), true)));
     }
 }

--- a/crates/bomber_game/src/player_behaviour.rs
+++ b/crates/bomber_game/src/player_behaviour.rs
@@ -49,8 +49,8 @@ pub struct Player {
 
 #[derive(Component, Clone, Debug)]
 pub struct Team {
-    name: String,
-    color: Color,
+    pub name: String,
+    pub color: Color,
 }
 
 pub struct KillPlayerEvent(pub Entity, pub PlayerName, pub Score);


### PR DESCRIPTION
One of the bevy migrations broke the podium screen, as we don't hold a handle to the texture as part of the player entities anymore.

This restores the behaviour plus fixes a couple minor issues with the podium (characters still animating in the background, missing team name)