### PR TITLE
Mix special and basic rounds

### DIFF
--- a/crates/bomber_game/src/game_map.rs
+++ b/crates/bomber_game/src/game_map.rs
@@ -87,14 +87,26 @@ fn setup(
             next_map.0 = 2;
         },
         MapIndex(2) => {
-            GameMap::spawn_from_text(&mut commands, RACE, &textures)?;
+            GameMap::spawn_from_text(&mut commands, CRATE_HEAVY_CROSS_ARENA_SMALL, &textures)?;
             next_map.0 = 3;
         },
         MapIndex(3) => {
-            GameMap::spawn_from_text(&mut commands, SHINGEKI, &textures)?;
+            GameMap::spawn_from_text(&mut commands, RACE, &textures)?;
             next_map.0 = 4;
         },
         MapIndex(4) => {
+            GameMap::spawn_from_text(&mut commands, CRATE_HEAVY_CROSS_ARENA_SMALL, &textures)?;
+            next_map.0 = 5;
+        },
+        MapIndex(5) => {
+            GameMap::spawn_from_text(&mut commands, SHINGEKI, &textures)?;
+            next_map.0 = 6;
+        },
+        MapIndex(6) => {
+            GameMap::spawn_from_text(&mut commands, CRATE_HEAVY_CROSS_ARENA_SMALL, &textures)?;
+            next_map.0 = 7;
+        },
+        MapIndex(7) => {
             GameMap::spawn_from_text(&mut commands, SPIRAL, &textures)?;
             next_map.0 = 0;
         },


### PR DESCRIPTION
Map rotation change born of a conversation with @bschwind .

While the new maps we've made are super cool, they're very unique and different, which means people won't really get a chance to see their strategies work until a new map completely changes the "rules", as it were.

We've decided to instead alternate a "basic" round (with a very simple map) and a "special" round, rotating through the cool unique maps we have. This hopefully means that people won't get lost as much and the special maps will be more exciting experiences :).